### PR TITLE
Publish to ClawHub as parcel-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenClaw plugin for [Parcel](https://parcelapp.net) package delivery tracking.
 ## Install
 
 ```bash
-openclaw plugins install openclaw-parcel
+openclaw plugins install parcel-cli
 ```
 
 ## Configuration
@@ -19,7 +19,7 @@ The plugin requires a **Parcel API Key** for list and add operations. Get yours 
 PARCEL_API_KEY=your-api-key
 
 # Reference via env interpolation in config
-openclaw config set plugins.entries.openclaw-parcel.config.apiKey '${PARCEL_API_KEY}'
+openclaw config set plugins.entries.parcel-cli.config.apiKey '${PARCEL_API_KEY}'
 ```
 
 ### Option B: SecretRef object (env source)
@@ -28,7 +28,7 @@ The plugin's `apiKey` config field accepts a SecretRef object directly:
 
 ```bash
 # Set PARCEL_API_KEY in your environment or ~/.openclaw/.env
-openclaw config set plugins.entries.openclaw-parcel.config.apiKey \
+openclaw config set plugins.entries.parcel-cli.config.apiKey \
   '{"source":"env","provider":"env","id":"PARCEL_API_KEY"}' --strict-json
 ```
 
@@ -39,7 +39,7 @@ openclaw config set plugins.entries.openclaw-parcel.config.apiKey \
 security add-generic-password -s 'env/PARCEL_API_KEY' -a "$USER" -w 'your-api-key'
 
 # Configure SecretRef to read from Keychain
-openclaw config set plugins.entries.openclaw-parcel.config.apiKey \
+openclaw config set plugins.entries.parcel-cli.config.apiKey \
   '{"source":"exec","provider":"keychain","id":"env/PARCEL_API_KEY"}' --strict-json
 ```
 
@@ -57,7 +57,7 @@ The plugin also resolves the API key from these sources (checked in order):
 
 | Source | Details |
 |--------|---------|
-| Plugin config (string) | `plugins.entries.openclaw-parcel.config.apiKey` |
+| Plugin config (string) | `plugins.entries.parcel-cli.config.apiKey` |
 | Plugin config (SecretRef) | Resolved via env, file, or exec provider |
 | Env var | `PARCEL_API_KEY` |
 | macOS Keychain | `env/PARCEL_API_KEY` |

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,12 @@
+{
+  "name": "parcel-cli",
+  "owner": { "name": "Omar Shahine" },
+  "plugins": [
+    {
+      "name": "parcel-cli",
+      "source": ".",
+      "description": "Track, add, edit, and remove package deliveries via the Parcel app",
+      "version": "1.2.0"
+    }
+  ]
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,6 +1,6 @@
 {
-  "id": "openclaw-parcel",
-  "name": "Parcel Tracking",
+  "id": "parcel-cli",
+  "name": "Parcel",
   "description": "Track, add, edit, and remove package deliveries via the Parcel app",
   "skills": ["skills/parcel-tracking"],
   "configSchema": {
@@ -32,7 +32,8 @@
         ],
         "description": "Parcel API key: plain string, ${ENV_VAR}, or SecretRef object"
       }
-    }
+    },
+    "additionalProperties": false
   },
   "uiHints": {
     "apiKey": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw-parcel",
+  "name": "parcel-cli",
   "version": "1.2.0",
   "description": "OpenClaw plugin for Parcel package delivery tracking",
   "type": "module",
@@ -37,7 +37,11 @@
   "engines": {
     "node": ">=18"
   },
+  "dependencies": {
+    "openclaw": "^2026.3.23"
+  },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "typescript": "^5.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "src/",
     "lib/",
     "skills/",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "marketplace.json"
   ],
   "keywords": [
     "openclaw",

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ function resolveApiKey(config?: PluginConfig): string | undefined {
 function toolResult(text: string) {
   return {
     content: [{ type: "text" as const, text }],
-    details: undefined,
+    details: null,
   };
 }
 
@@ -117,7 +117,7 @@ export default definePluginEntry({
     // --- parcel_list ---
     api.registerTool({
       name: "parcel_list",
-      label: "parcel_list",
+      label: "Parcel List",
       description:
         "List active and recent package deliveries from Parcel. Returns tracking info, status, carrier, and estimated delivery dates.",
       parameters: listSchema,
@@ -135,7 +135,7 @@ export default definePluginEntry({
     // --- parcel_add ---
     api.registerTool({
       name: "parcel_add",
-      label: "parcel_add",
+      label: "Parcel Add",
       description:
         "Add a new package to Parcel for tracking. Requires tracking number, carrier code, and description. Use parcel_carriers to look up carrier codes.",
       parameters: addSchema,
@@ -153,7 +153,7 @@ export default definePluginEntry({
     // --- parcel_edit ---
     api.registerTool({
       name: "parcel_edit",
-      label: "parcel_edit",
+      label: "Parcel Edit",
       description:
         "Edit a delivery's description on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
       parameters: editSchema,
@@ -169,7 +169,7 @@ export default definePluginEntry({
     // --- parcel_remove ---
     api.registerTool({
       name: "parcel_remove",
-      label: "parcel_remove",
+      label: "Parcel Remove",
       description:
         "Remove a delivery from Parcel on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
       parameters: removeSchema,
@@ -185,7 +185,7 @@ export default definePluginEntry({
     // --- parcel_carriers ---
     api.registerTool({
       name: "parcel_carriers",
-      label: "parcel_carriers",
+      label: "Parcel Carriers",
       description:
         "List supported carrier codes for adding deliveries to Parcel (ups, fedex, usps, dhl, amazon, etc.).",
       parameters: carriersSchema,
@@ -197,7 +197,7 @@ export default definePluginEntry({
     // --- parcel_status_codes ---
     api.registerTool({
       name: "parcel_status_codes",
-      label: "parcel_status_codes",
+      label: "Parcel Status Codes",
       description:
         "Reference for Parcel delivery status codes and their meanings (0=Delivered, 2=In transit, etc.).",
       parameters: statusCodesSchema,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
  * - parcel_carriers, parcel_status_codes (static reference)
  */
 
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { ParcelAPIClient } from "../lib/api-client.js";
 import {
   listSchema,
@@ -26,26 +27,6 @@ import {
 } from "../lib/handler.js";
 import { execFileSync } from "child_process";
 
-// OpenClaw plugin types
-
-interface TextContent {
-  type: "text";
-  text: string;
-}
-
-interface OpenClawToolDefinition {
-  name: string;
-  label: string;
-  description: string;
-  parameters: Record<string, unknown>;
-  execute: (
-    toolCallId: string,
-    params: Record<string, unknown>,
-    signal?: AbortSignal,
-    onUpdate?: (partialResult: unknown) => void
-  ) => Promise<{ content: TextContent[]; details?: unknown }>;
-}
-
 interface SecretRef {
   source: "env" | "file" | "exec";
   provider: string;
@@ -54,23 +35,6 @@ interface SecretRef {
 
 interface PluginConfig {
   apiKey?: string | SecretRef;
-}
-
-interface OpenClawPluginToolContext {
-  config?: Record<string, unknown>;
-  workspaceDir?: string;
-  agentId?: string;
-  sessionKey?: string;
-}
-
-type OpenClawPluginToolFactory = (
-  ctx: OpenClawPluginToolContext
-) => OpenClawToolDefinition | OpenClawToolDefinition[] | null | undefined;
-
-interface OpenClawContext {
-  config?: PluginConfig;
-  pluginConfig?: PluginConfig;
-  registerTool(toolOrFactory: OpenClawToolDefinition | OpenClawPluginToolFactory): void;
 }
 
 function keychainLookup(service: string): string | undefined {
@@ -121,114 +85,125 @@ function resolveApiKey(config?: PluginConfig): string | undefined {
 }
 
 /** Helper to wrap a handler result as tool output. */
-function toToolResult(result: Record<string, unknown>): { content: TextContent[] } {
+function toolResult(text: string) {
   return {
-    content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+    content: [{ type: "text" as const, text }],
+    details: undefined,
   };
 }
 
-function errorResult(message: string): { content: TextContent[] } {
+function toToolResult(result: Record<string, unknown>) {
+  return toolResult(JSON.stringify(result, null, 2));
+}
+
+function errorResult(message: string) {
   return toToolResult({ success: false, error: message });
 }
 
-export default function activate(context: OpenClawContext): void {
-  const config = context.config || context.pluginConfig;
+export default definePluginEntry({
+  id: "parcel-cli",
+  name: "Parcel",
+  description: "Track, add, edit, and remove package deliveries via the Parcel app",
 
-  // Helper: get API client or return error
-  function getApiClient(): ParcelAPIClient | null {
-    const apiKey = resolveApiKey(config);
-    return apiKey ? new ParcelAPIClient(apiKey) : null;
-  }
+  register(api) {
+    const config = api.pluginConfig as PluginConfig | undefined;
 
-  // --- parcel_list ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_list",
-    label: "Parcel List",
-    description:
-      "List active and recent package deliveries from Parcel. Returns tracking info, status, carrier, and estimated delivery dates.",
-    parameters: listSchema as Record<string, unknown>,
-    async execute(_toolCallId, params) {
-      const client = getApiClient();
-      if (!client) return errorResult("No Parcel API key configured.");
-      try {
-        return toToolResult(await handleList(params as { include_delivered?: boolean; limit?: number }, client));
-      } catch (e: unknown) {
-        return errorResult(e instanceof Error ? e.message : String(e));
-      }
-    },
-  }));
+    // Helper: get API client or return error
+    function getApiClient(): ParcelAPIClient | null {
+      const apiKey = resolveApiKey(config);
+      return apiKey ? new ParcelAPIClient(apiKey) : null;
+    }
 
-  // --- parcel_add ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_add",
-    label: "Parcel Add",
-    description:
-      "Add a new package to Parcel for tracking. Requires tracking number, carrier code, and description. Use parcel_carriers to look up carrier codes.",
-    parameters: addSchema as Record<string, unknown>,
-    async execute(_toolCallId, params) {
-      const client = getApiClient();
-      if (!client) return errorResult("No Parcel API key configured.");
-      try {
-        return toToolResult(await handleAdd(params as { tracking_number: string; carrier_code: string; description: string }, client));
-      } catch (e: unknown) {
-        return errorResult(e instanceof Error ? e.message : String(e));
-      }
-    },
-  }));
+    // --- parcel_list ---
+    api.registerTool({
+      name: "parcel_list",
+      label: "parcel_list",
+      description:
+        "List active and recent package deliveries from Parcel. Returns tracking info, status, carrier, and estimated delivery dates.",
+      parameters: listSchema,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const client = getApiClient();
+        if (!client) return errorResult("No Parcel API key configured.");
+        try {
+          return toToolResult(await handleList(params as { include_delivered?: boolean; limit?: number }, client));
+        } catch (e: unknown) {
+          return errorResult(e instanceof Error ? e.message : String(e));
+        }
+      },
+    });
 
-  // --- parcel_edit ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_edit",
-    label: "Parcel Edit",
-    description:
-      "Edit a delivery's description on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
-    parameters: editSchema as Record<string, unknown>,
-    async execute(_toolCallId, params) {
-      try {
-        return toToolResult(handleEdit(params as { tracking_number: string; description: string }));
-      } catch (e: unknown) {
-        return errorResult(e instanceof Error ? e.message : String(e));
-      }
-    },
-  }));
+    // --- parcel_add ---
+    api.registerTool({
+      name: "parcel_add",
+      label: "parcel_add",
+      description:
+        "Add a new package to Parcel for tracking. Requires tracking number, carrier code, and description. Use parcel_carriers to look up carrier codes.",
+      parameters: addSchema,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        const client = getApiClient();
+        if (!client) return errorResult("No Parcel API key configured.");
+        try {
+          return toToolResult(await handleAdd(params as { tracking_number: string; carrier_code: string; description: string }, client));
+        } catch (e: unknown) {
+          return errorResult(e instanceof Error ? e.message : String(e));
+        }
+      },
+    });
 
-  // --- parcel_remove ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_remove",
-    label: "Parcel Remove",
-    description:
-      "Remove a delivery from Parcel on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
-    parameters: removeSchema as Record<string, unknown>,
-    async execute(_toolCallId, params) {
-      try {
-        return toToolResult(handleRemove(params as { tracking_number: string }));
-      } catch (e: unknown) {
-        return errorResult(e instanceof Error ? e.message : String(e));
-      }
-    },
-  }));
+    // --- parcel_edit ---
+    api.registerTool({
+      name: "parcel_edit",
+      label: "parcel_edit",
+      description:
+        "Edit a delivery's description on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
+      parameters: editSchema,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        try {
+          return toToolResult(handleEdit(params as { tracking_number: string; description: string }));
+        } catch (e: unknown) {
+          return errorResult(e instanceof Error ? e.message : String(e));
+        }
+      },
+    });
 
-  // --- parcel_carriers ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_carriers",
-    label: "Parcel Carriers",
-    description:
-      "List supported carrier codes for adding deliveries to Parcel (ups, fedex, usps, dhl, amazon, etc.).",
-    parameters: carriersSchema as Record<string, unknown>,
-    async execute() {
-      return toToolResult(handleCarriers());
-    },
-  }));
+    // --- parcel_remove ---
+    api.registerTool({
+      name: "parcel_remove",
+      label: "parcel_remove",
+      description:
+        "Remove a delivery from Parcel on web.parcelapp.net. Returns browser automation instructions for OpenClaw's browser tool.",
+      parameters: removeSchema,
+      async execute(_toolCallId: string, params: Record<string, unknown>) {
+        try {
+          return toToolResult(handleRemove(params as { tracking_number: string }));
+        } catch (e: unknown) {
+          return errorResult(e instanceof Error ? e.message : String(e));
+        }
+      },
+    });
 
-  // --- parcel_status_codes ---
-  context.registerTool((_ctx: OpenClawPluginToolContext) => ({
-    name: "parcel_status_codes",
-    label: "Parcel Status Codes",
-    description:
-      "Reference for Parcel delivery status codes and their meanings (0=Delivered, 2=In transit, etc.).",
-    parameters: statusCodesSchema as Record<string, unknown>,
-    async execute() {
-      return toToolResult(handleStatusCodes());
-    },
-  }));
-}
+    // --- parcel_carriers ---
+    api.registerTool({
+      name: "parcel_carriers",
+      label: "parcel_carriers",
+      description:
+        "List supported carrier codes for adding deliveries to Parcel (ups, fedex, usps, dhl, amazon, etc.).",
+      parameters: carriersSchema,
+      async execute() {
+        return toToolResult(handleCarriers());
+      },
+    });
+
+    // --- parcel_status_codes ---
+    api.registerTool({
+      name: "parcel_status_codes",
+      label: "parcel_status_codes",
+      description:
+        "Reference for Parcel delivery status codes and their meanings (0=Delivered, 2=In transit, etc.).",
+      parameters: statusCodesSchema,
+      async execute() {
+        return toToolResult(handleStatusCodes());
+      },
+    });
+  },
+});


### PR DESCRIPTION
## Summary

- Migrate from raw `activate()` to SDK `definePluginEntry` pattern
- Rename plugin ID from `openclaw-parcel` to `parcel-cli` for ClawHub
- Add required `details` field to `AgentToolResult` responses
- Add `additionalProperties: false` to manifest `configSchema`
- Add `openclaw` as runtime dependency
- Create `marketplace.json` for ClawHub discovery
- Update README install instructions and config paths

## Test plan

- [ ] Verify plugin loads with `openclaw plugins list`
- [ ] Test `parcel_list` tool returns results with `details` field
- [ ] Publish to ClawHub: `openclaw plugins publish`
- [ ] Verify install works: `openclaw plugins install parcel-cli`

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)