### PR TITLE
fix: resolve SecretRef source=file + provider=secrets into shared secrets store

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ import {
   handleCarriers,
   handleStatusCodes,
 } from "../lib/handler.js";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 type ListParams = Static<typeof listSchema>;
 type AddParams = Static<typeof addSchema>;
@@ -72,6 +75,24 @@ function isSecretRef(value: unknown): value is SecretRef {
   );
 }
 
+/**
+ * Follow an RFC 6901 JSON pointer into a parsed JSON document. Returns
+ * undefined for missing paths or non-object traversals.
+ */
+function jsonPointer(doc: unknown, pointer: string): unknown {
+  if (!pointer || pointer === "/") return doc;
+  const parts = pointer
+    .replace(/^\//, "")
+    .split("/")
+    .map((p) => p.replace(/~1/g, "/").replace(/~0/g, "~"));
+  let cur: unknown = doc;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
 async function resolveSecretRef(ref: SecretRef): Promise<string | undefined> {
   switch (ref.source) {
     case "env":
@@ -79,6 +100,22 @@ async function resolveSecretRef(ref: SecretRef): Promise<string | undefined> {
     case "exec":
       if (ref.provider === "keychain" || ref.provider === "security") {
         return keychainLookup(ref.id);
+      }
+      return undefined;
+    case "file":
+      // OpenClaw shared-secrets-store: read ~/.openclaw/secrets.json and
+      // follow ref.id as a JSON pointer. Matches the pattern used by
+      // travel-hub, easypost, restaurant-cli, porsche-connect, instapaper.
+      if (ref.provider === "secrets") {
+        const secretsPath = join(homedir(), ".openclaw", "secrets.json");
+        if (!existsSync(secretsPath)) return undefined;
+        try {
+          const doc = JSON.parse(readFileSync(secretsPath, "utf8"));
+          const v = jsonPointer(doc, ref.id);
+          return typeof v === "string" && v ? v : undefined;
+        } catch {
+          return undefined;
+        }
       }
       return undefined;
     default:


### PR DESCRIPTION
## Summary

\`resolveSecretRef()\` previously only handled \`env\` and \`exec\` sources — so the idiomatic OpenClaw shared-store shape \`{source:"file", provider:"secrets", id:"/plugins/parcel/apiKey"}\` fell through to \`default: return undefined\`. The bug was masked in practice because \`resolveApiKey()\` has a \`process.env.PARCEL_API_KEY\` fallback that the gateway plist populates, so the plugin kept working — but the SecretRef in \`openclaw.json\` was effectively cosmetic.

## Fix

Add a \`file\` + \`provider: "secrets"\` branch that reads \`~/.openclaw/secrets.json\` and follows \`id\` as an RFC 6901 JSON pointer. Matches the pattern landed in:

- travel-hub (2026-04-15)
- omarshahine/restaurant-cli#22 (2026-04-18)
- omarshahine/porsche-connect#18 (2026-04-18)

Env-var and Keychain fallbacks remain in place for backwards compatibility.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] End-to-end: gateway restart with SecretRef config, probe that the plugin resolves the key from the shared store rather than the env fallback. Will verify after merge against Lobster.
- No unit tests added: no existing test infra in this plugin, and the resolver mirrors a pattern already covered by 7 tests in restaurant-cli#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)