### PR TITLE
chore: release Parcel plugin 2.0.11

### DIFF
--- a/marketplace.json
+++ b/marketplace.json
@@ -8,7 +8,7 @@
       "name": "openclaw-parcel",
       "source": ".",
       "description": "Track, add, edit, and remove package deliveries via the Parcel app",
-      "version": "2.0.10"
+      "version": "2.0.11"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-parcel",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-parcel",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.34.49",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-parcel",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "OpenClaw plugin for Parcel package delivery tracking",
   "type": "module",
   "openclaw": {


### PR DESCRIPTION
Version bump for the OpenClaw SDK refresh. Version consistency was checked locally before pushing.